### PR TITLE
Adding public `init` functions to all structs & responses

### DIFF
--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetSiteMetadata.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetSiteMetadata.swift
@@ -21,4 +21,8 @@ public struct GetSiteMetadataRequest: APIRequest {
 }
 public struct GetSiteMetadataResponse: APIResponse {
 	public let metadata: SiteMetadata
+
+	public init(metadata: SiteMetadata) {
+		self.metadata = metadata
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/AddAdmin.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/AddAdmin.swift
@@ -25,4 +25,8 @@ public struct AddAdminRequest: APIRequest {
 }
 public struct AddAdminResponse: APIResponse {
 	public let admins: [PersonViewSafe]
+
+	public init(admins: [PersonViewSafe]) {
+		self.admins = admins
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/AddModToCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/AddModToCommunity.swift
@@ -27,4 +27,8 @@ public struct AddModToCommunityRequest: APIRequest {
 }
 public struct AddModToCommunityResponse: APIResponse {
 	public let moderators: [CommunityModeratorView]
+
+	public init(moderators: [CommunityModeratorView]) {
+		self.moderators = moderators
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ApproveRegistrationApplication.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ApproveRegistrationApplication.swift
@@ -20,4 +20,8 @@ public struct ApproveRegistrationApplicationRequest: APIRequest {
 }
 public struct RegistrationApplicationResponse: APIResponse {
 	public let registration_application: RegistrationApplicationView
+
+	public init(registration_application: RegistrationApplicationView) {
+		self.registration_application = registration_application
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BanFromCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BanFromCommunity.swift
@@ -36,4 +36,9 @@ public struct BanFromCommunityRequest: APIRequest {
 public struct BanFromCommunityResponse: APIResponse {
 	public let banned: Bool
 	public let person_view: PersonViewSafe
+
+	public init(banned: Bool, person_view: PersonViewSafe) {
+		self.banned = banned
+		self.person_view = person_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BanPerson.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BanPerson.swift
@@ -21,8 +21,22 @@ public struct BanPersonRequest: APIRequest {
 	public let reason: String?
 	/// Removes/Restores their comments, posts, and communities.
 	public let remove_data: Bool?
+
+	public init(auth: String, ban: Bool, expires: Int? = nil, person_id: Int, reason: String? = nil, remove_data: Bool? = nil) {
+		self.auth = auth
+		self.ban = ban
+		self.expires = expires
+		self.person_id = person_id
+		self.reason = reason
+		self.remove_data = remove_data
+	}
 }
 public struct BanPersonResponse: APIResponse {
 	public let banned: Bool
 	public let person_view: PersonViewSafe
+
+	public init(banned: Bool, person_view: PersonViewSafe) {
+		self.banned = banned
+		self.person_view = person_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BlockCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BlockCommunity.swift
@@ -26,4 +26,9 @@ public struct BlockCommunityRequest: APIRequest {
 public struct BlockCommunityResponse: APIResponse {
 	public let blocked: Bool
 	public let community_view: CommunityView
+
+	public init(blocked: Bool, community_view: CommunityView) {
+		self.blocked = blocked
+		self.community_view = community_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BlockPerson.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/BlockPerson.swift
@@ -26,4 +26,9 @@ public struct BlockPersonRequest: APIRequest {
 public struct BlockPersonResponse: APIResponse {
 	public let blocked: Bool
 	public let person_view: PersonViewSafe
+
+	public init(blocked: Bool, person_view: PersonViewSafe) {
+		self.blocked = blocked
+		self.person_view = person_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateComment.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateComment.swift
@@ -19,9 +19,24 @@ public struct CreateCommentRequest: APIRequest {
 	public let language_id: Int?
 	public let parent_id: Int?
 	public let post_id: Int
+
+	public init(auth: String, content: String, form_id: String? = nil, language_id: Int? = nil, parent_id: Int? = nil, post_id: Int) {
+		self.auth = auth
+		self.content = content
+		self.form_id = form_id
+		self.language_id = language_id
+		self.parent_id = parent_id
+		self.post_id = post_id
+	}
 }
 public struct CommentResponse: APIResponse {
 	public let comment_view: CommentView
 	public let form_id: String?
 	public let recipient_ids: [Int]
+
+	public init(comment_view: CommentView, form_id: String? = nil, recipient_ids: [Int]) {
+		self.comment_view = comment_view
+		self.form_id = form_id
+		self.recipient_ids = recipient_ids
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateCommentReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateCommentReport.swift
@@ -25,4 +25,8 @@ public struct CreateCommentReportRequest: APIRequest {
 }
 public struct CommentReportResponse: APIResponse {
 	public let comment_report_view: CommentReportView
+
+	public init(comment_report_view: CommentReportView) {
+		self.comment_report_view = comment_report_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateCommunity.swift
@@ -38,4 +38,9 @@ public struct CreateCommunityRequest: APIRequest {
 public struct CommunityResponse: APIResponse {
 	public let community_view: CommunityView
 	public let discussion_languages: [Int]
+
+	public init(community_view: CommunityView, discussion_languages: [Int]) {
+		self.community_view = community_view
+		self.discussion_languages = discussion_languages
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePost.swift
@@ -35,4 +35,8 @@ public struct CreatePostRequest: APIRequest {
 }
 public struct PostResponse: APIResponse {
 	public let post_view: PostView
+
+	public init(post_view: PostView) {
+		self.post_view = post_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePostReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePostReport.swift
@@ -25,4 +25,8 @@ public struct CreatePostReportRequest: APIRequest {
 }
 public struct PostReportResponse: APIResponse {
 	public let post_report_view: PostReportView
+
+	public init(post_report_view: PostReportView) {
+		self.post_report_view = post_report_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePrivateMessage.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePrivateMessage.swift
@@ -25,4 +25,8 @@ public struct CreatePrivateMessageRequest: APIRequest {
 }
 public struct PrivateMessageResponse: APIResponse {
 	public let private_message_view: PrivateMessageView
+
+	public init(private_message_view: PrivateMessageView) {
+		self.private_message_view = private_message_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePrivateMessageReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreatePrivateMessageReport.swift
@@ -25,4 +25,8 @@ public struct CreatePrivateMessageReportRequest: APIRequest {
 }
 public struct PrivateMessageReportResponse: APIResponse {
 	public let private_message_report_view: PrivateMessageReportView
+
+	public init(private_message_report_view: PrivateMessageReportView) {
+		self.private_message_report_view = private_message_report_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateSite.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/CreateSite.swift
@@ -103,4 +103,8 @@ public struct CreateSiteRequest: APIRequest {
 }
 public struct SiteResponse: APIResponse {
 	public let site_view: SiteView
+
+	public init(site_view: SiteView) {
+		self.site_view = site_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/DeleteAccount.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/DeleteAccount.swift
@@ -22,4 +22,5 @@ public struct DeleteAccountRequest: APIRequest {
 	}
 }
 public struct DeleteAccountResponse: APIResponse {
+	public init() {}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/EditPrivateMessage.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/EditPrivateMessage.swift
@@ -16,4 +16,10 @@ public struct EditPrivateMessageRequest: APIRequest {
 	public let auth: String
 	public let content: String
 	public let private_message_id: Int
+
+	public init(auth: String, content: String, private_message_id: Int) {
+		self.auth = auth
+		self.content = content
+		self.private_message_id = private_message_id
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetBannedPersons.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetBannedPersons.swift
@@ -21,4 +21,8 @@ public struct GetBannedPersonsRequest: APIRequest {
 }
 public struct BannedPersonsResponse: APIResponse {
 	public let banned: [PersonViewSafe]
+
+	public init(banned: [PersonViewSafe]) {
+		self.banned = banned
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetCaptcha.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetCaptcha.swift
@@ -18,4 +18,8 @@ public struct GetCaptchaRequest: APIRequest {
 public struct GetCaptchaResponse: APIResponse {
 	/// Will be nil if captchas are disabled.
 	public let ok: CaptchaResponse?
+
+	public init(ok: CaptchaResponse? = nil) {
+		self.ok = ok
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetComments.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetComments.swift
@@ -41,4 +41,8 @@ public struct GetCommentsRequest: APIRequest {
 }
 public struct GetCommentsResponse: APIResponse {
 	public let comments: [CommentView]
+
+	public init(comments: [CommentView]) {
+		self.comments = comments
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetCommunity.swift
@@ -30,4 +30,13 @@ public struct GetCommunityResponse: APIResponse {
 	public let moderators: [CommunityModeratorView]
 	public let online: Int
 	public let site: Site?
+
+	public init(community_view: CommunityView, default_post_language: Int? = nil, discussion_languages: [Int], moderators: [CommunityModeratorView], online: Int, site: Site? = nil) {
+		self.community_view = community_view
+		self.default_post_language = default_post_language
+		self.discussion_languages = discussion_languages
+		self.moderators = moderators
+		self.online = online
+		self.site = site
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetModlog.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetModlog.swift
@@ -46,4 +46,21 @@ public struct GetModlogResponse: APIResponse {
 	public let removed_communities: [ModRemoveCommunityView]
 	public let removed_posts: [ModRemovePostView]
 	public let transferred_to_community: [ModTransferCommunityView]
+
+	public init(added: [ModAddView], added_to_community: [ModAddCommunityView], admin_purged_comments: [AdminPurgeCommentView], admin_purged_communities: [AdminPurgeCommunityView], admin_purged_persons: [AdminPurgePersonView], admin_purged_posts: [AdminPurgePostView], banned: [ModBanView], banned_from_community: [ModBanFromCommunityView], featured_posts: [ModFeaturePostView], locked_posts: [ModLockPostView], removed_comments: [ModRemoveCommentView], removed_communities: [ModRemoveCommunityView], removed_posts: [ModRemovePostView], transferred_to_community: [ModTransferCommunityView]) {
+		self.added = added
+		self.added_to_community = added_to_community
+		self.admin_purged_comments = admin_purged_comments
+		self.admin_purged_communities = admin_purged_communities
+		self.admin_purged_persons = admin_purged_persons
+		self.admin_purged_posts = admin_purged_posts
+		self.banned = banned
+		self.banned_from_community = banned_from_community
+		self.featured_posts = featured_posts
+		self.locked_posts = locked_posts
+		self.removed_comments = removed_comments
+		self.removed_communities = removed_communities
+		self.removed_posts = removed_posts
+		self.transferred_to_community = transferred_to_community
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPersonDetails.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPersonDetails.swift
@@ -39,4 +39,11 @@ public struct GetPersonDetailsResponse: APIResponse {
 	public let moderates: [CommunityModeratorView]
 	public let person_view: PersonViewSafe
 	public let posts: [PostView]
+
+	public init(comments: [CommentView], moderates: [CommunityModeratorView], person_view: PersonViewSafe, posts: [PostView]) {
+		self.comments = comments
+		self.moderates = moderates
+		self.person_view = person_view
+		self.posts = posts
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPersonMentions.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPersonMentions.swift
@@ -29,5 +29,9 @@ public struct GetPersonMentionsRequest: APIRequest {
 }
 public struct GetPersonMentionsResponse: APIResponse {
 	public let mentions: [PersonMentionView]
+
+	public init(mentions: [PersonMentionView]) {
+		self.mentions = mentions
+	}
 }
 

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPost.swift
@@ -28,4 +28,12 @@ public struct GetPostResponse: APIResponse {
 	public let moderators: [CommunityModeratorView]
 	public let online: Int
 	public let post_view: PostView
+
+	public init(community_view: CommunityView, moderators: [CommunityModeratorView], online: Int, post_view: PostView) {
+		self.community_view = community_view
+		self.moderators = moderators
+		self.online = online
+		self.post_view = post_view
+	}
+
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPosts.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPosts.swift
@@ -41,4 +41,8 @@ public struct GetPostsRequest: APIRequest {
 }
 public struct GetPostsResponse: APIResponse {
 	public let posts: [PostView]
+
+	public init(posts: [PostView]) {
+		self.posts = posts
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPrivateMessages.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetPrivateMessages.swift
@@ -27,4 +27,8 @@ public struct GetPrivateMessagesRequest: APIRequest {
 }
 public struct PrivateMessagesResponse: APIResponse {
 	public let private_messages: [PrivateMessageView]
+
+	public init(private_messages: [PrivateMessageView]) {
+		self.private_messages = private_messages
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetReplies.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetReplies.swift
@@ -21,4 +21,8 @@ public struct GetRepliesRequest: APIRequest {
 }
 public struct GetRepliesResponse: APIResponse {
 	public let replies: [CommentReplyView]
+
+	public init(replies: [CommentReplyView]) {
+		self.replies = replies
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetReportCount.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetReportCount.swift
@@ -27,4 +27,11 @@ public struct GetReportCountResponse: APIResponse {
 	public let community_id: Int?
 	public let post_reports: Int
 	public let private_message_reports: Int?
+
+	public init(comment_reports: Int, community_id: Int? = nil, post_reports: Int, private_message_reports: Int? = nil) {
+		self.comment_reports = comment_reports
+		self.community_id = community_id
+		self.post_reports = post_reports
+		self.private_message_reports = private_message_reports
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetSite.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetSite.swift
@@ -29,4 +29,16 @@ public struct GetSiteResponse: APIResponse {
 	public let site_view: SiteView
 	public let taglines: [Tagline]
 	public let version: String
+
+	public init(admins: [PersonViewSafe], all_languages: [Language], discussion_languages: [Int], federated_instances: FederatedInstances? = nil, my_user: MyUserInfo? = nil, online: Int, site_view: SiteView, taglines: [Tagline]? = nil, version: String) {
+		self.admins = admins
+		self.all_languages = all_languages
+		self.discussion_languages = discussion_languages
+		self.federated_instances = federated_instances
+		self.my_user = my_user
+		self.online = online
+		self.site_view = site_view
+		self.taglines = taglines
+		self.version = version
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetUnreadCount.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetUnreadCount.swift
@@ -23,4 +23,10 @@ public struct GetUnreadCountResponse: APIResponse {
 	public let mentions: Int
 	public let private_messages: Int
 	public let replies: Int
+
+	public init(mentions: Int, private_messages: Int, replies: Int) {
+		self.mentions = mentions
+		self.private_messages = private_messages
+		self.replies = replies
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetUnreadRegistrationApplicationCount.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/GetUnreadRegistrationApplicationCount.swift
@@ -21,4 +21,8 @@ public struct GetUnreadRegistrationApplicationCountRequest: APIRequest {
 }
 public struct GetUnreadRegistrationApplicationCountResponse: APIResponse {
 	public let registration_applications: Int
+
+	public init(registration_applications: Int) {
+		self.registration_applications = registration_applications
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListCommentReports.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListCommentReports.swift
@@ -31,4 +31,8 @@ public struct ListCommentReportsRequest: APIRequest {
 }
 public struct ListCommentReportsResponse: APIResponse {
 	public let comment_reports: [CommentReportView]
+
+	public init(comment_reports: [CommentReportView]) {
+		self.comment_reports = comment_reports
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListCommunities.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListCommunities.swift
@@ -29,4 +29,8 @@ public struct ListCommunitiesRequest: APIRequest {
 }
 public struct ListCommunitiesResponse: APIResponse {
 	public let communities: [CommunityView]
+
+	public init(communities: [CommunityView]) {
+		self.communities = communities
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListPostReports.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListPostReports.swift
@@ -31,4 +31,8 @@ public struct ListPostReportsRequest: APIRequest {
 }
 public struct ListPostReportsResponse: APIResponse {
 	public let post_reports: [PostReportView]
+
+	public init(post_reports: [PostReportView]) {
+		self.post_reports = post_reports
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListPrivateMessageReports.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListPrivateMessageReports.swift
@@ -27,4 +27,8 @@ public struct ListPrivateMessageReportsRequest: APIRequest {
 }
 public struct ListPrivateMessageReportsResponse: APIResponse {
 	public let private_message_reports: [PrivateMessageReportView]
+
+	public init(private_message_reports: [PrivateMessageReportView]) {
+		self.private_message_reports = private_message_reports
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListRegistrationApplications.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ListRegistrationApplications.swift
@@ -28,4 +28,8 @@ public struct ListRegistrationApplicationsRequest: APIRequest {
 }
 public struct ListRegistrationApplicationsResponse: APIResponse {
 	public let registration_applications: [RegistrationApplicationView]
+
+	public init(registration_applications: [RegistrationApplicationView]) {
+		self.registration_applications = registration_applications
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/Login.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/Login.swift
@@ -25,4 +25,10 @@ public struct LoginResponse: APIResponse {
 	public let jwt: String
 	public let registration_created: Bool
 	public let verify_email_sent: Bool
+
+	public init(jwt: String, registration_created: Bool, verify_email_sent: Bool) {
+		self.jwt = jwt
+		self.registration_created = registration_created
+		self.verify_email_sent = verify_email_sent
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/MarkPersonMentionAsRead.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/MarkPersonMentionAsRead.swift
@@ -25,4 +25,8 @@ public struct MarkPersonMentionAsReadRequest: APIRequest {
 }
 public struct PersonMentionResponse: APIResponse {
 	public let person_mention_view: PersonMentionView
+
+	public init(person_mention_view: PersonMentionView) {
+		self.person_mention_view = person_mention_view
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/PasswordReset.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/PasswordReset.swift
@@ -20,4 +20,5 @@ public struct PasswordResetRequest: APIRequest {
 	}
 }
 public struct PasswordResetResponse: APIResponse {
+	public init() {}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/PurgeComment.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/PurgeComment.swift
@@ -25,4 +25,8 @@ public struct PurgeCommentRequest: APIRequest {
 }
 public struct PurgeItemResponse: APIResponse {
 	public let success: Bool
+
+	public init(success: Bool) {
+		self.success = success
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ResolveObject.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/ResolveObject.swift
@@ -26,4 +26,11 @@ public struct ResolveObjectResponse: APIResponse {
 	public let community: CommunityView?
 	public let person: PersonViewSafe?
 	public let post: PostView?
+
+	public init(comment: CommentView? = nil, community: CommunityView? = nil, person: PersonViewSafe? = nil, post: PostView? = nil) {
+		self.comment = comment
+		self.community = community
+		self.person = person
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/Search.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/Search.swift
@@ -43,4 +43,12 @@ public struct SearchResponse: APIResponse {
 	public let posts: [PostView]
 	public let type_: String
 	public let users: [PersonViewSafe]
+
+	public init(comments: [CommentView], communities: [CommunityView], posts: [PostView], type_: String, users: [PersonViewSafe]) {
+		self.comments = comments
+		self.communities = communities
+		self.posts = posts
+		self.type_ = type_
+		self.users = users
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Requests/VerifyEmail.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Requests/VerifyEmail.swift
@@ -20,4 +20,5 @@ public struct VerifyEmailRequest: APIRequest {
 	}
 }
 public struct VerifyEmailResponse: APIResponse {
+	public init() {}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeComment.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeComment.swift
@@ -13,4 +13,12 @@ public struct AdminPurgeComment: Codable {
 	public let post_id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(admin_person_id: Int, id: Int, post_id: Int, reason: String? = nil, when_: String) {
+		self.admin_person_id = admin_person_id
+		self.id = id
+		self.post_id = post_id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommentView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommentView.swift
@@ -11,4 +11,10 @@ public struct AdminPurgeCommentView: Codable {
 	public let admin: PersonSafe?
 	public let admin_purge_comment: AdminPurgeComment
 	public let post: Post
+
+	public init(admin: PersonSafe? = nil, admin_purge_comment: AdminPurgeComment, post: Post) {
+		self.admin = admin
+		self.admin_purge_comment = admin_purge_comment
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommunity.swift
@@ -12,4 +12,11 @@ public struct AdminPurgeCommunity: Codable {
 	public let id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(admin_person_id: Int, id: Int, reason: String? = nil, when_: String) {
+		self.admin_person_id = admin_person_id
+		self.id = id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgeCommunityView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct AdminPurgeCommunityView: Codable {
 	public let admin: PersonSafe?
 	public let admin_purge_community: AdminPurgeCommunity
+
+	public init(admin: PersonSafe? = nil, admin_purge_community: AdminPurgeCommunity) {
+		self.admin = admin
+		self.admin_purge_community = admin_purge_community
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePerson.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePerson.swift
@@ -12,4 +12,11 @@ public struct AdminPurgePerson: Codable {
 	public let id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(admin_person_id: Int, id: Int, reason: String? = nil, when_: String) {
+		self.admin_person_id = admin_person_id
+		self.id = id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePersonView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePersonView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct AdminPurgePersonView: Codable {
 	public let admin: PersonSafe?
 	public let admin_purge_person: AdminPurgePerson
+
+	public init(admin: PersonSafe? = nil, admin_purge_person: AdminPurgePerson) {
+		self.admin = admin
+		self.admin_purge_person = admin_purge_person
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePost.swift
@@ -13,4 +13,12 @@ public struct AdminPurgePost: Codable {
 	public let id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(admin_person_id: Int, community_id: Int, id: Int, reason: String? = nil, when_: String) {
+		self.admin_person_id = admin_person_id
+		self.community_id = community_id
+		self.id = id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePostView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/AdminPurgePostView.swift
@@ -11,4 +11,10 @@ public struct AdminPurgePostView: Codable {
 	public let admin: PersonSafe?
 	public let admin_purge_post: AdminPurgePost
 	public let community: CommunitySafe
+
+	public init(admin: PersonSafe? = nil, admin_purge_post: AdminPurgePost, community: CommunitySafe) {
+		self.admin = admin
+		self.admin_purge_post = admin_purge_post
+		self.community = community
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CaptchaResponse.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CaptchaResponse.swift
@@ -14,4 +14,10 @@ public struct CaptchaResponse: Codable {
 	public let uuid: String
 	/// A Base64 encoded wav file.
 	public let wav: String?
+
+	public init(png: String, uuid: String, wav: String? = nil) {
+		self.png = png
+		self.uuid = uuid
+		self.wav = wav
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Comment.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Comment.swift
@@ -21,4 +21,20 @@ public struct Comment: Codable {
 	public let published: String
 	public let removed: Bool
 	public let updated: String?
+
+	public init(ap_id: String, content: String, creator_id: Int, deleted: Bool, distinguished: Bool, id: Int, language_id: Int, local: Bool, path: String, post_id: Int, published: String, removed: Bool, updated: String? = nil) {
+		self.ap_id = ap_id
+		self.content = content
+		self.creator_id = creator_id
+		self.deleted = deleted
+		self.distinguished = distinguished
+		self.id = id
+		self.language_id = language_id
+		self.local = local
+		self.path = path
+		self.post_id = post_id
+		self.published = published
+		self.removed = removed
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentAggregates.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentAggregates.swift
@@ -14,4 +14,13 @@ public struct CommentAggregates: Codable {
 	public let id: Int
 	public let score: Int
 	public let upvotes: Int
+
+	public init(child_count: Int, comment_id: Int, downvotes: Int, id: Int, score: Int, upvotes: Int) {
+		self.child_count = child_count
+		self.comment_id = comment_id
+		self.downvotes = downvotes
+		self.id = id
+		self.score = score
+		self.upvotes = upvotes
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReply.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReply.swift
@@ -13,4 +13,12 @@ public struct CommentReply: Codable {
 	public let published: String
 	public let read: Bool
 	public let recipient_id: Int
+
+	public init(comment_id: Int, id: Int, published: String, read: Bool, recipient_id: Int) {
+		self.comment_id = comment_id
+		self.id = id
+		self.published = published
+		self.read = read
+		self.recipient_id = recipient_id
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReplyView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReplyView.swift
@@ -20,4 +20,19 @@ public struct CommentReplyView: Codable {
 	public let recipient: PersonSafe
 	public let saved: Bool
 	public let subscribed: SubscribedType
+
+	public init(comment: Comment, comment_reply: CommentReply, community: CommunitySafe, counts: CommentAggregates, creator: PersonSafe, creator_banned_from_community: Bool, creator_blocked: Bool, my_vote: Int? = nil, post: Post, recipient: PersonSafe, saved: Bool, subscribed: SubscribedType) {
+		self.comment = comment
+		self.comment_reply = comment_reply
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.creator_blocked = creator_blocked
+		self.my_vote = my_vote
+		self.post = post
+		self.recipient = recipient
+		self.saved = saved
+		self.subscribed = subscribed
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReport.swift
@@ -17,4 +17,16 @@ public struct CommentReport: Codable {
 	public let resolved: Bool
 	public let resolver_id: Int?
 	public let updated: String?
+
+	public init(comment_id: Int, creator_id: Int, id: Int, original_comment_text: String, published: String, reason: String, resolved: Bool, resolver_id: Int? = nil, updated: String? = nil) {
+		self.comment_id = comment_id
+		self.creator_id = creator_id
+		self.id = id
+		self.original_comment_text = original_comment_text
+		self.published = published
+		self.reason = reason
+		self.resolved = resolved
+		self.resolver_id = resolver_id
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReportView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentReportView.swift
@@ -18,4 +18,17 @@ public struct CommentReportView: Codable {
 	public let my_vote: Int?
 	public let post: Post
 	public let resolver: PersonSafe?
+
+	public init(comment: Comment, comment_creator: PersonSafe, comment_report: CommentReport, community: CommunitySafe, counts: CommentAggregates, creator: PersonSafe, creator_banned_from_community: Bool, my_vote: Int? = nil, post: Post, resolver: PersonSafe? = nil) {
+		self.comment = comment
+		self.comment_creator = comment_creator
+		self.comment_report = comment_report
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.my_vote = my_vote
+		self.post = post
+		self.resolver = resolver
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommentView.swift
@@ -18,4 +18,17 @@ public struct CommentView: Codable {
 	public let post: Post
 	public let saved: Bool
 	public let subscribed: SubscribedType
+
+	public init(comment: Comment, community: CommunitySafe, counts: CommentAggregates, creator: PersonSafe, creator_banned_from_community: Bool, creator_blocked: Bool, my_vote: Int? = nil, post: Post, saved: Bool, subscribed: SubscribedType) {
+		self.comment = comment
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.creator_blocked = creator_blocked
+		self.my_vote = my_vote
+		self.post = post
+		self.saved = saved
+		self.subscribed = subscribed
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityAggregates.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityAggregates.swift
@@ -17,4 +17,16 @@ public struct CommunityAggregates: Codable {
 	public let users_active_half_year: Int
 	public let users_active_month: Int
 	public let users_active_week: Int
+
+	public init(comments: Int, community_id: Int, id: Int, posts: Int, subscribers: Int, users_active_day: Int, users_active_half_year: Int, users_active_month: Int, users_active_week: Int) {
+		self.comments = comments
+		self.community_id = community_id
+		self.id = id
+		self.posts = posts
+		self.subscribers = subscribers
+		self.users_active_day = users_active_day
+		self.users_active_half_year = users_active_half_year
+		self.users_active_month = users_active_month
+		self.users_active_week = users_active_week
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityBlockView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityBlockView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct CommunityBlockView: Codable {
 	public let community: CommunitySafe
 	public let person: PersonSafe
+
+	public init(community: CommunitySafe, person: PersonSafe) {
+		self.community = community
+		self.person = person
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityFolowerView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityFolowerView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct CommunityFolowerView: Codable {
 	public let community: CommunitySafe
 	public let follower: PersonSafe
+
+	public init(community: CommunitySafe, follower: PersonSafe) {
+		self.community = community
+		self.follower = follower
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityModeratorView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityModeratorView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct CommunityModeratorView: Codable {
 	public let community: CommunitySafe
 	public let moderator: PersonSafe
+
+	public init(community: CommunitySafe, moderator: PersonSafe) {
+		self.community = community
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunitySafe.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunitySafe.swift
@@ -24,4 +24,23 @@ public struct CommunitySafe: Codable {
 	public let removed: Bool
 	public let title: String
 	public let updated: String?
+
+	public init(actor_id: String, banner: String? = nil, deleted: Bool, description: String? = nil, hidden: Bool, icon: String? = nil, id: Int, instance_id: Int, local: Bool, name: String, nsfw: Bool, posting_restricted_to_mods: Bool, published: String, removed: Bool, title: String, updated: String? = nil) {
+		self.actor_id = actor_id
+		self.banner = banner
+		self.deleted = deleted
+		self.description = description
+		self.hidden = hidden
+		self.icon = icon
+		self.id = id
+		self.instance_id = instance_id
+		self.local = local
+		self.name = name
+		self.nsfw = nsfw
+		self.posting_restricted_to_mods = posting_restricted_to_mods
+		self.published = published
+		self.removed = removed
+		self.title = title
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/CommunityView.swift
@@ -12,4 +12,11 @@ public struct CommunityView: Codable {
 	public let community: CommunitySafe
 	public let counts: CommunityAggregates
 	public let subscribed: SubscribedType
+
+	public init(blocked: Bool, community: CommunitySafe, counts: CommunityAggregates, subscribed: SubscribedType) {
+		self.blocked = blocked
+		self.community = community
+		self.counts = counts
+		self.subscribed = subscribed
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/FederatedInstances.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/FederatedInstances.swift
@@ -11,4 +11,10 @@ public struct FederatedInstances: Codable {
 	public let allowed: [String]
 	public let blocked: [String]
 	public let linked: [String]
+
+	public init(allowed: [String]? = nil, blocked: [String]? = nil, linked: [String]) {
+		self.allowed = allowed
+		self.blocked = blocked
+		self.linked = linked
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Language.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Language.swift
@@ -11,4 +11,10 @@ public struct Language: Codable {
 	public let code: String
 	public let id: Int
 	public let name: String
+
+	public init(code: String, id: Int, name: String) {
+		self.code = code
+		self.id = id
+		self.name = name
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalSite.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalSite.swift
@@ -33,4 +33,32 @@ public struct LocalSite: Codable {
 	public let site_setup: Bool
 	public let slur_filter_regex: String?
 	public let updated: String?
+
+	public init(actor_name_max_length: Int, application_email_admins: Bool, application_question: String? = nil, captcha_difficulty: String, captcha_enabled: Bool, community_creation_admin_only: Bool, default_post_listing_type: String, default_theme: String, enable_downvotes: Bool, enable_nsfw: Bool, federation_debug: Bool, federation_enabled: Bool, federation_worker_count: Int, hide_modlog_mod_names: Bool, id: Int, legal_information: String? = nil, private_instance: Bool, published: String, registration_mode: RegistrationMode, reports_email_admins: Bool, require_email_verification: Bool, site_id: Int, site_setup: Bool, slur_filter_regex: String? = nil, updated: String? = nil) {
+		self.actor_name_max_length = actor_name_max_length
+		self.application_email_admins = application_email_admins
+		self.application_question = application_question
+		self.captcha_difficulty = captcha_difficulty
+		self.captcha_enabled = captcha_enabled
+		self.community_creation_admin_only = community_creation_admin_only
+		self.default_post_listing_type = default_post_listing_type
+		self.default_theme = default_theme
+		self.enable_downvotes = enable_downvotes
+		self.enable_nsfw = enable_nsfw
+		self.federation_debug = federation_debug
+		self.federation_enabled = federation_enabled
+		self.federation_worker_count = federation_worker_count
+		self.hide_modlog_mod_names = hide_modlog_mod_names
+		self.id = id
+		self.legal_information = legal_information
+		self.private_instance = private_instance
+		self.published = published
+		self.registration_mode = registration_mode
+		self.reports_email_admins = reports_email_admins
+		self.require_email_verification = require_email_verification
+		self.site_id = site_id
+		self.site_setup = site_setup
+		self.slur_filter_regex = slur_filter_regex
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalSiteRateLimit.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalSiteRateLimit.swift
@@ -24,4 +24,23 @@ public struct LocalSiteRateLimit: Codable {
 	public let search: Int
 	public let search_per_second: Int
 	public let updated: String?
+
+	public init(comment: Int, comment_per_second: Int, id: Int, image: Int, image_per_second: Int, local_site_id: Int, message: Int, message_per_second: Int, post: Int, post_per_second: Int, published: String, register: Int, register_per_second: Int, search: Int, search_per_second: Int, updated: String? = nil) {
+		self.comment = comment
+		self.comment_per_second = comment_per_second
+		self.id = id
+		self.image = image
+		self.image_per_second = image_per_second
+		self.local_site_id = local_site_id
+		self.message = message
+		self.message_per_second = message_per_second
+		self.post = post
+		self.post_per_second = post_per_second
+		self.published = published
+		self.register = register
+		self.register_per_second = register_per_second
+		self.search = search
+		self.search_per_second = search_per_second
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalUserSettings.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalUserSettings.swift
@@ -25,4 +25,24 @@ public struct LocalUserSettings: Codable {
 	public let show_scores: Bool
 	public let theme: String
 	public let validator_time: String
+
+	public init(accepted_application: Bool, default_listing_type: Int, default_sort_type: Int, email: String? = nil, email_verified: Bool, id: Int, interface_language: String, person_id: Int, send_notifications_to_email: Bool, show_avatars: Bool, show_bot_accounts: Bool, show_new_post_notifs: Bool, show_nsfw: Bool, show_read_posts: Bool, show_scores: Bool, theme: String, validator_time: String) {
+		self.accepted_application = accepted_application
+		self.default_listing_type = default_listing_type
+		self.default_sort_type = default_sort_type
+		self.email = email
+		self.email_verified = email_verified
+		self.id = id
+		self.interface_language = interface_language
+		self.person_id = person_id
+		self.send_notifications_to_email = send_notifications_to_email
+		self.show_avatars = show_avatars
+		self.show_bot_accounts = show_bot_accounts
+		self.show_new_post_notifs = show_new_post_notifs
+		self.show_nsfw = show_nsfw
+		self.show_read_posts = show_read_posts
+		self.show_scores = show_scores
+		self.theme = theme
+		self.validator_time = validator_time
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalUserSettingsView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/LocalUserSettingsView.swift
@@ -11,4 +11,10 @@ public struct LocalUserSettingsView: Codable {
 	public let counts: PersonAggregates
 	public let local_user: LocalUserSettings
 	public let person: PersonSafe
+
+	public init(counts: PersonAggregates, local_user: LocalUserSettings, person: PersonSafe) {
+		self.counts = counts
+		self.local_user = local_user
+		self.person = person
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAdd.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAdd.swift
@@ -13,4 +13,12 @@ public struct ModAdd: Codable {
 	public let other_person_id: Int
 	public let removed: Bool?
 	public let when_: String
+
+	public init(id: Int, mod_person_id: Int, other_person_id: Int, removed: Bool? = nil, when_: String) {
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.other_person_id = other_person_id
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddCommunity.swift
@@ -14,4 +14,13 @@ public struct ModAddCommunity: Codable {
 	public let other_person_id: Int
 	public let removed: Bool?
 	public let when_: String
+
+	public init(community_id: Int, id: Int, mod_person_id: Int, other_person_id: Int, removed: Bool? = nil, when_: String) {
+		self.community_id = community_id
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.other_person_id = other_person_id
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddCommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddCommunityView.swift
@@ -12,4 +12,12 @@ public struct ModAddCommunityView: Codable {
 	public let mod_add_community: ModAddCommunity
 	public let modded_person: PersonSafe
 	public let moderator: PersonSafe
+
+	public init(community: CommunitySafe, mod_add_community: ModAddCommunity, modded_person: PersonSafe, moderator: PersonSafe) {
+		self.community = community
+		self.mod_add_community = mod_add_community
+		self.modded_person = modded_person
+		self.moderator = moderator
+	}
+
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModAddView.swift
@@ -11,4 +11,10 @@ public struct ModAddView: Codable {
 	public let mod_add: ModAdd
 	public let modded_person: PersonSafe
 	public let moderator: PersonSafe?
+
+	public init(mod_add: ModAdd, modded_person: PersonSafe, moderator: PersonSafe? = nil) {
+		self.mod_add = mod_add
+		self.modded_person = modded_person
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBan.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBan.swift
@@ -15,4 +15,14 @@ public struct ModBan: Codable {
 	public let other_person_id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(banned: Bool, expires: String, id: Int, mod_person_id: Int, other_person_id: Int, reason: String? = nil, when_: String) {
+		self.banned = banned
+		self.expires = expires
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.other_person_id = other_person_id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanFromCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanFromCommunity.swift
@@ -16,4 +16,15 @@ public struct ModBanFromCommunity: Codable {
 	public let other_person_id: Int
 	public let reason: String?
 	public let when_: String
+
+	public init(banned: Bool? = nil, community_id: Int, expires: String? = nil, id: Int, mod_person_id: Int, other_person_id: Int, reason: String? = nil, when_: String) {
+		self.banned = banned
+		self.community_id = community_id
+		self.expires = expires
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.other_person_id = other_person_id
+		self.reason = reason
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanFromCommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanFromCommunityView.swift
@@ -12,4 +12,11 @@ public struct ModBanFromCommunityView: Codable {
 	public let community: CommunitySafe
 	public let mod_ban_from_community: ModBanFromCommunity
 	public let moderator: PersonSafe?
+
+	public init(banned_person: PersonSafe, community: CommunitySafe, mod_ban_from_community: ModBanFromCommunity, moderator: PersonSafe? = nil) {
+		self.banned_person = banned_person
+		self.community = community
+		self.mod_ban_from_community = mod_ban_from_community
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModBanView.swift
@@ -11,4 +11,10 @@ public struct ModBanView: Codable {
 	public let banned_person: PersonSafe
 	public let mod_ban: ModBan
 	public let moderator: PersonSafe?
+
+	public init(banned_person: PersonSafe, mod_ban: ModBan, moderator: PersonSafe? = nil) {
+		self.banned_person = banned_person
+		self.mod_ban = mod_ban
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModFeaturePost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModFeaturePost.swift
@@ -14,4 +14,13 @@ public struct ModFeaturePost: Codable {
 	public let mod_person_id: Int
 	public let post_id: Int
 	public let when_: String
+
+	public init(featured: Bool, id: Int, is_featured_community: Bool, mod_person_id: Int, post_id: Int, when_: String) {
+		self.featured = featured
+		self.id = id
+		self.is_featured_community = is_featured_community
+		self.mod_person_id = mod_person_id
+		self.post_id = post_id
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModFeaturePostView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModFeaturePostView.swift
@@ -12,4 +12,11 @@ public struct ModFeaturePostView: Codable {
 	public let mod_feature_post: ModFeaturePost
 	public let moderator: PersonSafe?
 	public let post: Post
+
+	public init(community: CommunitySafe, mod_feature_post: ModFeaturePost, moderator: PersonSafe? = nil, post: Post) {
+		self.community = community
+		self.mod_feature_post = mod_feature_post
+		self.moderator = moderator
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModLockPost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModLockPost.swift
@@ -13,4 +13,12 @@ public struct ModLockPost: Codable {
 	public let mod_person_id: Int
 	public let post_id: Int
 	public let when_: String
+
+	public init(id: Int, locked: Bool? = nil, mod_person_id: Int, post_id: Int, when_: String) {
+		self.id = id
+		self.locked = locked
+		self.mod_person_id = mod_person_id
+		self.post_id = post_id
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModLockPostView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModLockPostView.swift
@@ -12,4 +12,11 @@ public struct ModLockPostView: Codable {
 	public let mod_lock_post: ModLockPost
 	public let moderator: PersonSafe?
 	public let post: Post
+
+	public init(community: CommunitySafe, mod_lock_post: ModLockPost, moderator: PersonSafe? = nil, post: Post) {
+		self.community = community
+		self.mod_lock_post = mod_lock_post
+		self.moderator = moderator
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveComment.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveComment.swift
@@ -14,4 +14,13 @@ public struct ModRemoveComment: Codable {
 	public let reason: String?
 	public let removed: Bool?
 	public let when_: String
+
+	public init(comment_id: Int, id: Int, mod_person_id: Int, reason: String? = nil, removed: Bool? = nil, when_: String) {
+		self.comment_id = comment_id
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.reason = reason
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommentView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommentView.swift
@@ -14,4 +14,13 @@ public struct ModRemoveCommentView: Codable {
 	public let mod_remove_comment: ModRemoveComment
 	public let moderator: PersonSafe?
 	public let post: Post
+
+	public init(comment: Comment, commenter: PersonSafe, community: CommunitySafe, mod_remove_comment: ModRemoveComment, moderator: PersonSafe? = nil, post: Post) {
+		self.comment = comment
+		self.commenter = commenter
+		self.community = community
+		self.mod_remove_comment = mod_remove_comment
+		self.moderator = moderator
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommunity.swift
@@ -15,4 +15,14 @@ public struct ModRemoveCommunity: Codable {
 	public let reason: String?
 	public let removed: Bool?
 	public let when_: String
+
+	public init(community_id: Int, expires: String? = nil, id: Int, mod_person_id: Int, reason: String? = nil, removed: Bool? = nil, when_: String) {
+		self.community_id = community_id
+		self.expires = expires
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.reason = reason
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemoveCommunityView.swift
@@ -11,4 +11,10 @@ public struct ModRemoveCommunityView: Codable {
 	public let community: CommunitySafe
 	public let mod_remove_community: ModRemoveCommunity
 	public let moderator: PersonSafe?
+
+	public init(community: CommunitySafe, mod_remove_community: ModRemoveCommunity, moderator: PersonSafe? = nil) {
+		self.community = community
+		self.mod_remove_community = mod_remove_community
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemovePost.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemovePost.swift
@@ -14,4 +14,13 @@ public struct ModRemovePost: Codable {
 	public let reason: String?
 	public let removed: Bool?
 	public let when_: String
+
+	public init(id: Int, mod_person_id: Int, post_id: Int, reason: String? = nil, removed: Bool? = nil, when_: String) {
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.post_id = post_id
+		self.reason = reason
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemovePostView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModRemovePostView.swift
@@ -12,4 +12,11 @@ public struct ModRemovePostView: Codable {
 	public let mod_remove_post: ModRemovePost
 	public let moderator: PersonSafe?
 	public let post: Post
+
+	public init(community: CommunitySafe, mod_remove_post: ModRemovePost, moderator: PersonSafe? = nil, post: Post) {
+		self.community = community
+		self.mod_remove_post = mod_remove_post
+		self.moderator = moderator
+		self.post = post
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModTransferCommunity.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModTransferCommunity.swift
@@ -14,4 +14,13 @@ public struct ModTransferCommunity: Codable {
 	public let other_person_id: Int
 	public let removed: Bool?
 	public let when_: String
+
+	public init(community_id: Int, id: Int, mod_person_id: Int, other_person_id: Int, removed: Bool? = nil, when_: String) {
+		self.community_id = community_id
+		self.id = id
+		self.mod_person_id = mod_person_id
+		self.other_person_id = other_person_id
+		self.removed = removed
+		self.when_ = when_
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModTransferCommunityView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/ModTransferCommunityView.swift
@@ -12,4 +12,11 @@ public struct ModTransferCommunityView: Codable {
 	public let mod_transfer_community: ModTransferCommunity
 	public let modded_person: PersonSafe
 	public let moderator: PersonSafe?
+
+	public init(community: CommunitySafe, mod_transfer_community: ModTransferCommunity, modded_person: PersonSafe, moderator: PersonSafe? = nil) {
+		self.community = community
+		self.mod_transfer_community = mod_transfer_community
+		self.modded_person = modded_person
+		self.moderator = moderator
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/MyUserInfo.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/MyUserInfo.swift
@@ -14,4 +14,13 @@ public struct MyUserInfo: Codable {
 	public let local_user_view: LocalUserSettingsView
 	public let moderates: [CommunityModeratorView]
 	public let person_blocks: [PersonBlockView]
+
+	public init(community_blocks: [CommunityBlockView], discussion_languages: [Int], follows: [CommunityFolowerView], local_user_view: LocalUserSettingsView, moderates: [CommunityModeratorView], person_blocks: [PersonBlockView]) {
+		self.community_blocks = community_blocks
+		self.discussion_languages = discussion_languages
+		self.follows = follows
+		self.local_user_view = local_user_view
+		self.moderates = moderates
+		self.person_blocks = person_blocks
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonAggregates.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonAggregates.swift
@@ -14,4 +14,13 @@ public struct PersonAggregates: Codable {
 	public let person_id: Int
 	public let post_count: Int
 	public let post_score: Int
+
+	public init(comment_count: Int, comment_score: Int, id: Int, person_id: Int, post_count: Int, post_score: Int) {
+		self.comment_count = comment_count
+		self.comment_score = comment_score
+		self.id = id
+		self.person_id = person_id
+		self.post_count = post_count
+		self.post_score = post_score
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonBlockView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonBlockView.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct PersonBlockView: Codable {
 	public let person: PersonSafe
 	public let target: PersonSafe
+
+	public init(person: PersonSafe, target: PersonSafe) {
+		self.person = person
+		self.target = target
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonMention.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonMention.swift
@@ -13,4 +13,12 @@ public struct PersonMention: Codable {
 	public let published: String
 	public let read: Bool
 	public let recipient_id: Int
+
+	public init(comment_id: Int, id: Int, published: String, read: Bool, recipient_id: Int) {
+		self.comment_id = comment_id
+		self.id = id
+		self.published = published
+		self.read = read
+		self.recipient_id = recipient_id
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonMentionView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonMentionView.swift
@@ -20,4 +20,19 @@ public struct PersonMentionView: Codable {
 	public let recipient: PersonSafe
 	public let saved: Bool
 	public let subscribed: SubscribedType
+
+	public init(comment: Comment, community: CommunitySafe, counts: CommentAggregates, creator: PersonSafe, creator_banned_from_community: Bool, creator_blocked: Bool, my_vote: Int? = nil, person_mention: PersonMention, post: Post, recipient: PersonSafe, saved: Bool, subscribed: SubscribedType) {
+		self.comment = comment
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.creator_blocked = creator_blocked
+		self.my_vote = my_vote
+		self.person_mention = person_mention
+		self.post = post
+		self.recipient = recipient
+		self.saved = saved
+		self.subscribed = subscribed
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonSafe.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonSafe.swift
@@ -27,4 +27,26 @@ public struct PersonSafe: Codable {
 	public let published: String
 	public let shared_inbox_url: String?
 	public let updated: String?
+
+	public init(actor_id: String, admin: Bool, avatar: String? = nil, ban_expires: String? = nil, banned: Bool, banner: String? = nil, bio: String? = nil, bot_account: Bool, deleted: Bool, display_name: String? = nil, id: Int, inbox_url: String, instance_id: Int, local: Bool, matrix_user_id: String? = nil, name: String, published: String, shared_inbox_url: String? = nil, updated: String? = nil) {
+		self.actor_id = actor_id
+		self.admin = admin
+		self.avatar = avatar
+		self.ban_expires = ban_expires
+		self.banned = banned
+		self.banner = banner
+		self.bio = bio
+		self.bot_account = bot_account
+		self.deleted = deleted
+		self.display_name = display_name
+		self.id = id
+		self.inbox_url = inbox_url
+		self.instance_id = instance_id
+		self.local = local
+		self.matrix_user_id = matrix_user_id
+		self.name = name
+		self.published = published
+		self.shared_inbox_url = shared_inbox_url
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonViewSafe.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonViewSafe.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct PersonViewSafe: Codable {
 	public let counts: PersonAggregates
 	public let person: PersonSafe
+
+	public init(counts: PersonAggregates, person: PersonSafe) {
+		self.counts = counts
+		self.person = person
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Post.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Post.swift
@@ -29,5 +29,29 @@ public struct Post: Codable {
 	public let thumbnail_url: String?
 	public let updated: String?
 	public let url: String?
+
+	public init(ap_id: String, body: String? = nil, community_id: Int, creator_id: Int, deleted: Bool, embed_description: String? = nil, embed_title: String? = nil, embed_video_url: String? = nil, featured_community: Bool, featured_local: Bool, id: Int, language_id: Int, local: Bool, locked: Bool, name: String, nsfw: Bool, published: String, removed: Bool, thumbnail_url: String? = nil, updated: String? = nil, url: String? = nil) {
+		self.ap_id = ap_id
+		self.body = body
+		self.community_id = community_id
+		self.creator_id = creator_id
+		self.deleted = deleted
+		self.embed_description = embed_description
+		self.embed_title = embed_title
+		self.embed_video_url = embed_video_url
+		self.featured_community = featured_community
+		self.featured_local = featured_local
+		self.id = id
+		self.language_id = language_id
+		self.local = local
+		self.locked = locked
+		self.name = name
+		self.nsfw = nsfw
+		self.published = published
+		self.removed = removed
+		self.thumbnail_url = thumbnail_url
+		self.updated = updated
+		self.url = url
+	}
 }
 

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostAggregates.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostAggregates.swift
@@ -19,4 +19,17 @@ public struct PostAggregates: Codable {
 	public let post_id: Int
 	public let score: Int
 	public let upvotes: Int
+
+	public init(comments: Int, downvotes: Int, featured_community: Bool, featured_local: Bool, id: Int, newest_comment_time: String, newest_comment_time_necro: String, post_id: Int, score: Int, upvotes: Int) {
+		self.comments = comments
+		self.downvotes = downvotes
+		self.featured_community = featured_community
+		self.featured_local = featured_local
+		self.id = id
+		self.newest_comment_time = newest_comment_time
+		self.newest_comment_time_necro = newest_comment_time_necro
+		self.post_id = post_id
+		self.score = score
+		self.upvotes = upvotes
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostReport.swift
@@ -19,4 +19,18 @@ public struct PostReport: Codable {
 	public let resolved: Bool
 	public let resolved_id: Int?
 	public let updated: String?
+
+	public init(creator_id: Int, id: Int, original_post_body: String? = nil, original_post_name: String, original_post_url: String? = nil, post_id: Int, published: String, reason: String, resolved: Bool, resolved_id: Int? = nil, updated: String? = nil) {
+		self.creator_id = creator_id
+		self.id = id
+		self.original_post_body = original_post_body
+		self.original_post_name = original_post_name
+		self.original_post_url = original_post_url
+		self.post_id = post_id
+		self.published = published
+		self.reason = reason
+		self.resolved = resolved
+		self.resolved_id = resolved_id
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostReportView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostReportView.swift
@@ -17,4 +17,16 @@ public struct PostReportView: Codable {
 	public let post_creator: PersonSafe
 	public let post_report: PostReport
 	public let resolver: PersonSafe?
+
+	public init(community: CommunitySafe, counts: PostAggregates, creator: PersonSafe, creator_banned_from_community: Bool, my_vote: Int? = nil, post: Post, post_creator: PersonSafe, post_report: PostReport, resolver: PersonSafe? = nil) {
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.my_vote = my_vote
+		self.post = post
+		self.post_creator = post_creator
+		self.post_report = post_report
+		self.resolver = resolver
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PostView.swift
@@ -19,4 +19,18 @@ public struct PostView: Codable {
 	public let saved: Bool
 	public let subscribed: SubscribedType
 	public let unread_comments: Int
+
+	public init(community: CommunitySafe, counts: PostAggregates, creator: PersonSafe, creator_banned_from_community: Bool, creator_blocked: Bool, my_vote: Int? = nil, post: Post, read: Bool, saved: Bool, subscribed: SubscribedType, unread_comments: Int) {
+		self.community = community
+		self.counts = counts
+		self.creator = creator
+		self.creator_banned_from_community = creator_banned_from_community
+		self.creator_blocked = creator_blocked
+		self.my_vote = my_vote
+		self.post = post
+		self.read = read
+		self.saved = saved
+		self.subscribed = subscribed
+		self.unread_comments = unread_comments
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessage.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessage.swift
@@ -18,4 +18,17 @@ public struct PrivateMessage: Codable {
 	public let read: Bool
 	public let recipient_id: Int
 	public let updated: String?
+
+	public init(ap_id: String, content: String, creator_id: Int, deleted: Bool, id: Int, local: Bool, published: String, read: Bool, recipient_id: Int, updated: String? = nil) {
+		self.ap_id = ap_id
+		self.content = content
+		self.creator_id = creator_id
+		self.deleted = deleted
+		self.id = id
+		self.local = local
+		self.published = published
+		self.read = read
+		self.recipient_id = recipient_id
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageReport.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageReport.swift
@@ -17,4 +17,16 @@ public struct PrivateMessageReport: Codable {
 	public let resolved: Bool
 	public let resolver_id: Int?
 	public let updated: String?
+
+	public init(creator_id: Int, id: Int, original_pm_text: String, private_message_id: Int, published: String, reason: String, resolved: Bool, resolver_id: Int? = nil, updated: String? = nil) {
+		self.creator_id = creator_id
+		self.id = id
+		self.original_pm_text = original_pm_text
+		self.private_message_id = private_message_id
+		self.published = published
+		self.reason = reason
+		self.resolved = resolved
+		self.resolver_id = resolver_id
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageReportView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageReportView.swift
@@ -13,4 +13,12 @@ public struct PrivateMessageReportView: Codable {
 	public let private_message_creator: PersonSafe
 	public let private_message_report: PrivateMessageReport
 	public let resolver: PersonSafe?
+
+	public init(creator: PersonSafe, private_message: PrivateMessage, private_message_creator: PersonSafe, private_message_report: PrivateMessageReport, resolver: PersonSafe? = nil) {
+		self.creator = creator
+		self.private_message = private_message
+		self.private_message_creator = private_message_creator
+		self.private_message_report = private_message_report
+		self.resolver = resolver
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PrivateMessageView.swift
@@ -11,4 +11,10 @@ public struct PrivateMessageView: Codable {
 	public let creator: PersonSafe
 	public let private_message: PrivateMessage
 	public let recipient: PersonSafe
+
+	public init(creator: PersonSafe, private_message: PrivateMessage, recipient: PersonSafe) {
+		self.creator = creator
+		self.private_message = private_message
+		self.recipient = recipient
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/RegistrationApplication.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/RegistrationApplication.swift
@@ -14,4 +14,13 @@ public struct RegistrationApplication: Codable {
 	public let id: Int
 	public let local_user_id: Int
 	public let published: String
+
+	public init(admin_id: Int? = nil, answer: String, deny_reason: String, id: Int, local_user_id: Int, published: String) {
+		self.admin_id = admin_id
+		self.answer = answer
+		self.deny_reason = deny_reason
+		self.id = id
+		self.local_user_id = local_user_id
+		self.published = published
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/RegistrationApplicationView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/RegistrationApplicationView.swift
@@ -12,4 +12,11 @@ public struct RegistrationApplicationView: Codable {
 	public let creator: PersonSafe
 	public let creator_local_user: LocalUserSettings
 	public let registration_application: RegistrationApplication
+
+	public init(admin: PersonSafe? = nil, creator: PersonSafe, creator_local_user: LocalUserSettings, registration_application: RegistrationApplication) {
+		self.admin = admin
+		self.creator = creator
+		self.creator_local_user = creator_local_user
+		self.registration_application = registration_application
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Site.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Site.swift
@@ -22,4 +22,21 @@ public struct Site: Codable {
 	public let published: String
 	public let sidebar: String?
 	public let updated: String?
+
+	public init(actor_id: String, banner: String? = nil, description: String? = nil, icon: String? = nil, id: Int, inbox_url: String, instance_id: Int, last_refreshed_at: String, name: String, private_key: String? = nil, public_key: String, published: String, sidebar: String? = nil, updated: String? = nil) {
+		self.actor_id = actor_id
+		self.banner = banner
+		self.description = description
+		self.icon = icon
+		self.id = id
+		self.inbox_url = inbox_url
+		self.instance_id = instance_id
+		self.last_refreshed_at = last_refreshed_at
+		self.name = name
+		self.private_key = private_key
+		self.public_key = public_key
+		self.published = published
+		self.sidebar = sidebar
+		self.updated = updated
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteAggregates.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteAggregates.swift
@@ -18,4 +18,17 @@ public struct SiteAggregates: Codable {
 	public let users_active_half_year: Int
 	public let users_active_month: Int
 	public let users_active_week: Int
+
+	public init(comments: Int, communities: Int, id: Int, posts: Int, site_id: Int, users: Int, users_active_day: Int, users_active_half_year: Int, users_active_month: Int, users_active_week: Int) {
+		self.comments = comments
+		self.communities = communities
+		self.id = id
+		self.posts = posts
+		self.site_id = site_id
+		self.users = users
+		self.users_active_day = users_active_day
+		self.users_active_half_year = users_active_half_year
+		self.users_active_month = users_active_month
+		self.users_active_week = users_active_week
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteMetadata.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteMetadata.swift
@@ -12,4 +12,11 @@ public struct SiteMetadata: Codable {
 	public let html: String?
 	public let image: String?
 	public let title: String?
+
+	public init(description: String? = nil, html: String? = nil, image: String? = nil, title: String? = nil) {
+		self.description = description
+		self.html = html
+		self.image = image
+		self.title = title
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteView.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/SiteView.swift
@@ -13,4 +13,12 @@ public struct SiteView: Codable {
 	public let local_site_rate_limit: LocalSiteRateLimit
 	public let site: Site
 	public let taglines: [Tagline]?
+
+	public init(counts: SiteAggregates, local_site: LocalSite, local_site_rate_limit: LocalSiteRateLimit, site: Site, taglines: [Tagline]? = nil) {
+		self.counts = counts
+		self.local_site = local_site
+		self.local_site_rate_limit = local_site_rate_limit
+		self.site = site
+		self.taglines = taglines
+	}
 }

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Tagline.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/Tagline.swift
@@ -13,4 +13,12 @@ public struct Tagline: Codable {
 	public let local_site_id: Int
 	public let published: String
 	public let updated: String?
+
+	public init(content: String, id: Int, local_site_id: Int, published: String, updated: String? = nil) {
+		self.content = content
+		self.id = id
+		self.local_site_id = local_site_id
+		self.published = published
+		self.updated = updated
+	}
 }


### PR DESCRIPTION
This PR adds public `init` functions to all structs & responses. This makes it much easier to test and mock responses from the Lemmy API within your Swift projects.