### PR TITLE
LemmyAPI cleanup, documentation, test preparation

### DIFF
--- a/Sources/Lemmy-Swift-Client/Extensions/URLSession+Session.swift
+++ b/Sources/Lemmy-Swift-Client/Extensions/URLSession+Session.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+extension URLSession: Session {}
+

--- a/Sources/Lemmy-Swift-Client/LemmyAPI.swift
+++ b/Sources/Lemmy-Swift-Client/LemmyAPI.swift
@@ -7,12 +7,20 @@ public final class LemmyAPI {
 
 	let session: Session
 
+	/// Initializes an instance of ``LemmyAPI``.
+	/// - Parameters:
+	///   - baseUrl: The base `URL` for the API including the API path (e.g. https://lemmy.ml/api/v3).
+	///   - headers: Additional headers to send with each request (default: `nil`).
+	///   - session: The `Session` implementation to send requests with (default: `URLSession.shared`).
 	public init(baseUrl: URL, headers: [String: String]? = nil, session: Session = URLSession.shared) {
 		self.baseUrl = baseUrl
 		self.headers = headers
 		self.session = session
 	}
 
+	/// Asynchronously sends an ``APIRequest`` and returns its ``APIRequest.Response`` or returns an error.
+	/// - Parameter apiRequest: The ``APIRequest`` to send.
+	/// - Returns: The response received as an ``APIRequest.Response``.
 	public func request<T: APIRequest>(_ apiRequest: T) async throws -> T.Response {
 		let urlRequest = try makeUrlRequest(for: apiRequest)
 		let (data, _) = try await session.data(for: urlRequest)

--- a/Sources/Lemmy-Swift-Client/Lemmy_Swift_Client.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy_Swift_Client.swift
@@ -33,6 +33,11 @@ public final class LemmyAPI {
 		} else {
 			request.httpBody = try JSONEncoder().encode(apiRequest)
 		}
+
+		headers?.forEach { (header, value) in
+			request.setValue(value, forHTTPHeaderField: header)
+		}
+
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
 		return request

--- a/Sources/Lemmy-Swift-Client/Lemmy_Swift_Client.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy_Swift_Client.swift
@@ -1,21 +1,28 @@
 import Foundation
 
 /// An instance of the Lemmy API.
-public class LemmyAPI {
+public final class LemmyAPI {
 	private let baseUrl: URL
 	private let headers: [String: String]?
-	private let urlSession: URLSession
 
-	public init(baseUrl: URL, headers: [String: String]? = nil, urlSession: URLSession = .shared) {
+	let session: Session
+
+	public init(baseUrl: URL, headers: [String: String]? = nil, session: Session = URLSession.shared) {
 		self.baseUrl = baseUrl
 		self.headers = headers
-		self.urlSession = urlSession
+		self.session = session
 	}
 
 	public func request<T: APIRequest>(_ apiRequest: T) async throws -> T.Response {
+		let urlRequest = try makeUrlRequest(for: apiRequest)
+		let (data, _) = try await session.data(for: urlRequest)
+		return try JSONDecoder().decode(T.Response.self, from: data)
+	}
+	
+	func makeUrlRequest<T: APIRequest>(for apiRequest: T) throws -> URLRequest {
 		var request = URLRequest(url: baseUrl.appending(path: T.path))
 		request.httpMethod = T.httpMethod.rawValue
-		let encoder = JSONEncoder()
+
 		if T.httpMethod == .get {
 			let mirror = Mirror(reflecting: apiRequest)
 			request.url = request.url?.appending(queryItems: mirror.children.compactMap { (label, value) in
@@ -24,12 +31,11 @@ public class LemmyAPI {
 				return URLQueryItem(name: label, value: String(describing: valueString))
 			})
 		} else {
-			request.httpBody = try encoder.encode(apiRequest)
+			request.httpBody = try JSONEncoder().encode(apiRequest)
 		}
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		let (data, _) = try await urlSession.data(for: request)
-		let decoder = JSONDecoder()
-		return try decoder.decode(T.Response.self, from: data)
+
+		return request
 	}
 }
 

--- a/Sources/Lemmy-Swift-Client/Protocols/Session.swift
+++ b/Sources/Lemmy-Swift-Client/Protocols/Session.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public typealias SessionResponse = (Data, URLResponse)
+
+public protocol Session {
+	func data(for request: URLRequest) async throws -> SessionResponse
+}


### PR DESCRIPTION
This PR is making some changes to the `LemmyAPI` class.

* The `LemmyAPI` class is now marked as `final`.
* Added the `Session` protocol which is now used instead of `URLSession` directly. This can come in handy for testing.
* Moved the `URLRequest` creation into its own method (see below for reasoning).
* Actually add contents of the `headers` dictionary to the generated `URLRequest`.
* Renamed `Lemmy_Swift_Client.swift` to `LemmyAPI.swift`.
* Added developer documentation to `init` and `request` on `LemmyAPI`.

The goal here was to clean up the class a little, add something here and there. No major changes in behavior except for adding the `headers` to the actual sent request.

I moved the `URLRequest` generation into its own method because I'm preparing another set of changes which will add fully optional support for creating Combine publishers from `LemmyAPI` and therefore I would need this logic in multiple different places. In this next PR there will also be some small test cases for this particular implementation, hence the `Session` protocol.