### PR TITLE
Conforming all enums to CaseIterable

### DIFF
--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/CommentSortType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/CommentSortType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum CommentSortType: String, Codable, CustomStringConvertible {
+public enum CommentSortType: String, Codable, CustomStringConvertible, CaseIterable {
 	/// Comments sorted by a decaying rank.
 	case hot = "Hot"
 	/// Comments sorted by new.

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/ListingType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/ListingType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum ListingType: String, Codable, CustomStringConvertible {
+public enum ListingType: String, Codable, CustomStringConvertible, CaseIterable {
 	case all = "All"
 	case community = "Community"
 	case local = "Local"

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/ModlogActionType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/ModlogActionType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum ModlogActionType: String, Codable, CustomStringConvertible {
+public enum ModlogActionType: String, Codable, CustomStringConvertible, CaseIterable {
 	case adminPurgeComment = "AdminPurgeComment"
 	case adminPurgeCommunity = "AdminPurgeCommunity"
 	case adminPurgePerson = "AdminPurgePerson"

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/PostFeatureType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/PostFeatureType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum PostFeatureType: String, Codable, CustomStringConvertible {
+public enum PostFeatureType: String, Codable, CustomStringConvertible, CaseIterable {
 	case community = "Community"
 	case local = "Local"
 

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/RegistrationMode.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/RegistrationMode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum RegistrationMode: String, Codable, CustomStringConvertible {
+public enum RegistrationMode: String, Codable, CustomStringConvertible, CaseIterable {
 	case closed = "closed"
 	case open = "open"
 	case requireApplication = "requireapplication"

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SearchType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SearchType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum SearchType: String, Codable, CustomStringConvertible {
+public enum SearchType: String, Codable, CustomStringConvertible, CaseIterable {
 	case all = "All"
 	case comments = "Comments"
 	case communities = "Communities"

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SortType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SortType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Different post sort types used in lemmy.
-public enum SortType: String, Codable, CustomStringConvertible {
+public enum SortType: String, Codable, CustomStringConvertible, CaseIterable {
 	/// Posts sorted by hot, but bumped by new comments up to 2 days.
 	case active = "Active"
 	/// Posts sorted by a decaying rank.

--- a/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SubscribedType.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Enums/SubscribedType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum SubscribedType: String, Codable, CustomStringConvertible {
+public enum SubscribedType: String, Codable, CustomStringConvertible, CaseIterable {
 	case notSubscribed = "NotSubscribed"
 	case pending = "Pending"
 	case subscribed = "Subscribed"


### PR DESCRIPTION
This PR conforms all of the Lemmy-Swift-Client enums to CaseIterable