### PR TITLE
Addressed a critical error in relation to inbox_url on the PersonSafe struct

### DIFF
--- a/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonSafe.swift
+++ b/Sources/Lemmy-Swift-Client/Lemmy API/Structs/PersonSafe.swift
@@ -19,7 +19,7 @@ public struct PersonSafe: Codable {
 	public let deleted: Bool
 	public let display_name: String?
 	public let id: Int
-	public let inbox_url: String
+	public let inbox_url: String?
 	public let instance_id: Int
 	public let local: Bool
 	public let matrix_user_id: String?
@@ -28,7 +28,7 @@ public struct PersonSafe: Codable {
 	public let shared_inbox_url: String?
 	public let updated: String?
 
-	public init(actor_id: String, admin: Bool, avatar: String? = nil, ban_expires: String? = nil, banned: Bool, banner: String? = nil, bio: String? = nil, bot_account: Bool, deleted: Bool, display_name: String? = nil, id: Int, inbox_url: String, instance_id: Int, local: Bool, matrix_user_id: String? = nil, name: String, published: String, shared_inbox_url: String? = nil, updated: String? = nil) {
+	public init(actor_id: String, admin: Bool, avatar: String? = nil, ban_expires: String? = nil, banned: Bool, banner: String? = nil, bio: String? = nil, bot_account: Bool, deleted: Bool, display_name: String? = nil, id: Int, inbox_url: String?, instance_id: Int, local: Bool, matrix_user_id: String? = nil, name: String, published: String, shared_inbox_url: String? = nil, updated: String? = nil) {
 		self.actor_id = actor_id
 		self.admin = admin
 		self.avatar = avatar


### PR DESCRIPTION
This might be related to the 0.18 update that released a few days ago, but it appears that inbox_url no longer appears on the Person type sent back from the server. As a result, any requests that utilize PersonSafe will fail to decode as a result of a missing coding key. 

**Changes Made:**

- Updated the Person struct to make the inbox_url property optional.
- Updated the init to conform to the change.

These changes ensure that the code can handle the possible deprecation of inbox_url while remaining compatible with instances that might still use it.

Please review and merge these changes at your convenience. Thank you.